### PR TITLE
Remove the scrollbar and fix alignment of Gmail logo on go/nickofbh.

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         <h1>Nick Kortendick</h1>
         <h2>Chicago ✈ Palo Alto</h2>
         <h2>Hail to the Orange</h2>
-        <h2>Software Engineer on <a href="https://mail.google.com" target="_blank"><img src="https://ssl.gstatic.com/ui/v1/icons/mail/images/favicon5.ico"/></a></h2>
+        <h2 class="job-title">Software Engineer on&nbsp;<a href="https://mail.google.com" target="_blank"><img src="https://ssl.gstatic.com/ui/v1/icons/mail/images/favicon5.ico"/></a></h2>
       </div>
       <div class="socialicons">
         <ul>

--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@ html {
 body {
   display: flex;
   height: 100%;
+  margin: 0;
 }
 
 h1, h2 {

--- a/style.css
+++ b/style.css
@@ -26,6 +26,12 @@ h2 {
   line-height: 22px;
 }
 
+.job-title {
+  align-items: center; 
+  display: flex;
+  margin-top: 4px;
+}
+
 img {
   max-height: 400px;
   max-width: 100%


### PR DESCRIPTION
Fixes two P0 issues on go/nickofbh:

1. The Gmail logo was aligned with the top of the text, which means it stuck 2px below the bottom of the text. This made my eyes bleed.
2. There was an unnecessary scrollbar that took away from the stark whiteness of the page.

Video of changes: https://drive.google.com/open?id=13C4sXjnOfPRb1dwzroKmIoc38krmuiMT